### PR TITLE
Use secret data from secrets listed in deployments.

### DIFF
--- a/k8s/k8sfabricator.go
+++ b/k8s/k8sfabricator.go
@@ -693,9 +693,9 @@ func (k *K8Fabricator) GetAllPodsEnvsByServiceId(creds K8sClusterCredentials, sp
 			simpleContainer.Envs = map[string]string{}
 
 			for _, env := range container.Env {
-				if env.Value == "" {
+				if env.Value == "" && env.ValueFrom.SecretKeyRef != nil {
 					logger.Debug("Empty env value, searching env variable in secrets")
-					simpleContainer.Envs[env.Name] = findSecretValue(secrets, env.ValueFrom.SecretKeyRef.Name, envNameToSecretKey(env.Name))
+					simpleContainer.Envs[env.Name] = findSecretValue(secrets, env.ValueFrom.SecretKeyRef)
 				} else {
 					simpleContainer.Envs[env.Name] = env.Value
 				}
@@ -708,23 +708,18 @@ func (k *K8Fabricator) GetAllPodsEnvsByServiceId(creds K8sClusterCredentials, sp
 	return result, nil
 }
 
-func envNameToSecretKey(env_name string) string {
-	lower_case_string := strings.ToLower(env_name)
-	return strings.Replace(lower_case_string, "_", "-", -1)
-}
-
-func findSecretValue(secrets *api.SecretList, secretName string, secretKey string) string {
+func findSecretValue(secrets *api.SecretList, selector *api.SecretKeySelector) string {
 	for _, secret := range secrets.Items {
-		if secret.Name != secretName {
+		if secret.Name != selector.Name {
 			continue
 		}
 		for key, value := range secret.Data {
-			if key == secretKey {
+			if key == selector.Key {
 				return string((value))
 			}
 		}
 	}
-	logger.Info("Secret key not found: ", secretKey)
+	logger.Info("Secret key not found: ", selector.Key)
 	return ""
 }
 

--- a/k8s/k8sfabricator_test.go
+++ b/k8s/k8sfabricator_test.go
@@ -255,12 +255,11 @@ func TestGetAllPodsEnvsByServiceId(t *testing.T) {
 					Spec: api.PodSpec{
 						Containers: []api.Container{{
 							Env: []api.EnvVar{{
-								Name: "secret",
+								Name: "secret-env",
 								ValueFrom: &api.EnvVarSource{
 									SecretKeyRef: &api.SecretKeySelector{
-										LocalObjectReference: api.LocalObjectReference{
-											Name: "secret",
-										},
+										LocalObjectReference: api.LocalObjectReference{Name: "secret-name"},
+										Key:                  "secret-key",
 									},
 								}},
 							}},
@@ -285,9 +284,9 @@ func TestGetAllPodsEnvsByServiceId(t *testing.T) {
 			secrets := api.SecretList{
 				Items: []api.Secret{
 					api.Secret{
-						ObjectMeta: api.ObjectMeta{Name: "secret"},
+						ObjectMeta: api.ObjectMeta{Name: "secret-name"},
 						Data: map[string][]byte{
-							"secret": []byte("secret"),
+							"secret-key": []byte("secret-value"),
 						},
 					},
 				},
@@ -300,16 +299,16 @@ func TestGetAllPodsEnvsByServiceId(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(envs, ShouldHaveLength, 1)
 			So(envs[0].Containers, ShouldHaveLength, 1)
-			So(envs[0].Containers[0].Envs["secret"], ShouldEqual, "secret")
+			So(envs[0].Containers[0].Envs["secret-env"], ShouldEqual, "secret-value")
 		})
 
 		Convey("Should return empty string when no matching secret", func() {
 			secrets := api.SecretList{
 				Items: []api.Secret{
 					api.Secret{
-						ObjectMeta: api.ObjectMeta{Name: "anothersecret"},
+						ObjectMeta: api.ObjectMeta{Name: "another-secret-name"},
 						Data: map[string][]byte{
-							"secret": []byte("secret"),
+							"secret-key": []byte("secret-value"),
 						},
 					},
 				},


### PR DESCRIPTION
- Get secret data from secret listed in deployment spec
- Expand tests for getting secrets

This resolves a bug where multiple secrets include the same keys. For
example, the mongodb30 service creates two secrets, each of which
includes a `mongodb-username` key.
